### PR TITLE
Feat/swipeable tabs

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import Temperature from '@/views/Temperature/index.vue'
 import Containers from '@/views/Containers/index.vue'
 import ExceptionRegistration from '@/views/ExceptionRegistration/index.vue'
 import Dispatch from '@/views/Dispatch/index.vue'
+import RestaurantList from '@/views/Dispatch/RestaurantList/index.vue'
 import Main from '@/views/Main/index.vue'
 import EntryRecord from '@/views/EntryRecord/index.vue'
 import Restaurant from '@/views/Restaurant/index.vue'
@@ -63,6 +64,10 @@ const router = createRouter({
     {
       path: '/pallet',
       component: Pallet,
+    },
+    {
+      path: '/restaurantlist',
+      component: RestaurantList,
     },
     {
       path: '/precool',

--- a/src/views/Dispatch/RestaurantList/index.vue
+++ b/src/views/Dispatch/RestaurantList/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { NavBar } from 'vant'
+import { NavBar, Tab, Tabs } from 'vant'
 import { onMounted } from 'vue'
 import useDispatchInfo from '@/views/Dispatch/store'
 
@@ -7,9 +7,136 @@ const dispatchStore = useDispatchInfo()
 onMounted(() => {
   console.log(dispatchStore)
 })
+
+const mockTabStatus = {
+  DELIVERING: '配送中', //配送中(1) 已抵達(2)
+  PENDING_DELIVERY: '待配送', //待配送(0) 延後配送(11)
+  DELIVERY_COMPLETED: '配送完成', //配送完成(4) 攜回配銷中心(3)
+  UNABLE_DELIVERY: '無法配送', //無法配送(12)
+}
+
+// 無配送資料時，渲染tab
+// const mockStoreByStatusEmpty = {
+//   DELIVERING: [],
+//   PENDING_DELIVERY: [],
+//   DELIVERY_COMPLETED: [],
+//   UNABLE_DELIVERY: [],
+// }
+
+// 有配送資料時，依照status分成四種狀態，渲染tab
+const mockStoreByStatus = {
+  DELIVERING: [
+    {
+      id: 'DS62a976485a631',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 1,
+    },
+    {
+      id: 'DS62a976485a637',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 2,
+    },
+  ],
+  PENDING_DELIVERY: [
+    {
+      id: 'DS62a976485a632',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 0,
+    },
+    {
+      id: 'DS62a976485a633',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 11,
+    },
+  ],
+  DELIVERY_COMPLETED: [
+    {
+      id: 'DS62a976485a635',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 4,
+    },
+    {
+      id: 'DS62a976485a636',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 13,
+    },
+  ],
+  UNABLE_DELIVERY: [
+    {
+      id: 'DS62a976485a634',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 12,
+    },
+  ],
+}
 </script>
 
 <template>
-  <NavBar safe-area-inset-top fixed title="派工單id" />
-  <div class="bg-main bg-opacity-5 h-screen">餐廳明細列表頁面</div>
+  <div class="bg-primary/[.05] min-h-screen pt-[46px] box-border">
+    <!-- 導航列 -->
+    <NavBar safe-area-inset-top left-arrow fixed title="餐廳明細"></NavBar>
+    <div class="pt-4 px-[26px] text-[13px]">
+      <Tabs :swipeable="true">
+        <Tab v-for="(item, index) in mockStoreByStatus" :title="mockTabStatus[index]" :key="index">
+          <div class="h-screen py-10">{{ mockTabStatus[index] }} 内容</div>
+        </Tab>
+      </Tabs>
+    </div>
+  </div>
 </template>
+
+<style scoped>
+:deep(.van-tab--active) {
+  color: #eb5e55;
+  font-weight: 900;
+}
+:deep(.van-tabs__line) {
+  width: 19px;
+  height: 4px;
+}
+:deep(.van-tabs__nav) {
+  background-color: rgba(255, 255, 255, 0);
+}
+</style>

--- a/src/views/Dispatch/index.vue
+++ b/src/views/Dispatch/index.vue
@@ -49,6 +49,21 @@ const handleToPallet = async (dispatch) => {
     },
   })
 }
+
+// 待修改
+const fakeHandleToRestaurantList = async (dispatch) => {
+  router.push({
+    path: '/restaurantlist',
+    query: {
+      dispatch_id: dispatch.id,
+      dispatch_no: dispatch.no,
+      car_id,
+      container_id,
+      container_number,
+      car_number,
+    },
+  })
+}
 </script>
 
 <template>
@@ -97,8 +112,8 @@ const handleToPallet = async (dispatch) => {
           <Button
             size="mini"
             round
-            disabled
             class="border-2 border-solid border-neutral-500 bg-neutral-500 text-white px-3 py-1"
+            @click="fakeHandleToRestaurantList(dispatch)"
           >
             餐廳明細
           </Button>


### PR DESCRIPTION
#61 
1. 有用假資料模擬餐廳明細頁。
2. 看設計圖時，發現一個tab可能會包含兩種status的配送card，因此有備註如下 (在 `src\views\Dispatch\RestaurantList\index.vue`)
```
const mockTabStatus = {
  DELIVERING: '配送中', //配送中(1) 已抵達(2)
  PENDING_DELIVERY: '待配送', //待配送(0) 延後配送(11)
  DELIVERY_COMPLETED: '配送完成', //配送完成(4) 攜回配銷中心(3)
  UNABLE_DELIVERY: '無法配送', //無法配送(12)
}
```
不確定用這樣的結構來處理O不OK

3. 另有在dispatch用一個假的function，引導至餐廳明細頁
4. 影片範例和設計圖的tab數量不一致，我是照設計圖做